### PR TITLE
docs: 저비용 MVP 인프라 구성으로 설계 문서 전면 개편

### DIFF
--- a/docs/architecture/SYSTEM_ARCHITECTURE.md
+++ b/docs/architecture/SYSTEM_ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 코딩테스트 연습 플랫폼의 전체 시스템 아키텍처 문서입니다.
 
-## 1. 시스템 개요
+## 1. 시스템 개요 (저비용 MVP)
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -12,25 +12,38 @@
                                   │ HTTPS
                                   ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│                           API Gateway / Load Balancer                        │
-│                              (Nginx / AWS ALB)                               │
+│                              Vercel (Frontend)                               │
 └─────────────────────────────────┬───────────────────────────────────────────┘
-                                  │
+                                  │ API Calls
                                   ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│                          Backend API (Spring Boot)                           │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐        │
-│  │  Problem    │  │    Run      │  │   Submit    │  │  History    │        │
-│  │  Service    │  │   Service   │  │   Service   │  │  Service    │        │
-│  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘        │
-└────────┬────────────────┬────────────────┬────────────────┬─────────────────┘
-         │                │                │                │
-         ▼                ▼                ▼                ▼
-┌─────────────┐    ┌─────────────┐  ┌─────────────┐  ┌─────────────┐
-│ PostgreSQL  │    │   Judge0    │  │    Redis    │  │    Redis    │
-│   (Data)    │    │  (Execute)  │  │   (Queue)   │  │   (Cache)   │
-└─────────────┘    └─────────────┘  └─────────────┘  └─────────────┘
+│                      Single VM (Backend + Judge0)                            │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │                    Backend API (Spring Boot)                         │   │
+│  │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐                  │   │
+│  │  │  Problem    │  │    Run      │  │   Submit    │                  │   │
+│  │  │  Service    │  │   Service   │  │   Service   │                  │   │
+│  │  └─────────────┘  └─────────────┘  └─────────────┘                  │   │
+│  │         │                │                │                          │   │
+│  │         ▼                ▼                ▼                          │   │
+│  │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐                  │   │
+│  │  │   SQLite    │  │   Judge0    │  │  In-Memory  │                  │   │
+│  │  │   (Data)    │  │  (Execute)  │  │   Queue     │                  │   │
+│  │  └─────────────┘  └─────────────┘  └─────────────┘                  │   │
+│  └─────────────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────────────┘
 ```
+
+### 1.1 아키텍처 원칙 (MVP)
+
+| 원칙 | 설명 |
+|------|------|
+| **단순성** | 최소한의 컴포넌트로 구성 |
+| **비용 효율** | 월 1만원 이하 운영 |
+| **단일 서버** | 모든 백엔드를 하나의 VM에서 실행 |
+| **내장 솔루션** | Redis 대신 인메모리 큐, PostgreSQL 대신 SQLite |
+
+---
 
 ## 2. 컴포넌트 상세
 
@@ -41,8 +54,9 @@
 | Framework | Next.js 14+ (App Router) |
 | UI Library | shadcn/ui (Radix UI 기반) |
 | Code Editor | Monaco Editor |
-| State Management | React Context / Zustand / React Query |
-| HTTP Client | Axios / Fetch API |
+| State Management | React Context / Zustand |
+| HTTP Client | Fetch API |
+| Hosting | **Vercel Free Tier** |
 
 **주요 페이지:**
 - `/` - 문제 리스트
@@ -64,42 +78,89 @@
 ```
 ├── ProblemService        # 문제 CRUD, 템플릿 제공
 ├── RunService            # 샘플 테스트 실행 (동기)
-├── SubmitService         # 전체 테스트 제출 (비동기)
+├── SubmitService         # 전체 테스트 제출 (인메모리 큐 + 비동기)
 ├── ExecutionService      # Judge0 연동
 ├── SubmissionService     # 제출 이력 관리
 └── GuestSessionService   # 게스트 토큰 관리
 ```
 
-### 2.3 Execution Engine (Judge0)
+### 2.3 Database (SQLite)
+
+| 항목 | 설명 |
+|------|------|
+| Database | SQLite 3.x |
+| ORM | Spring Data JPA + Hibernate |
+| Migration | Flyway |
+| Location | 파일 기반 (VM 로컬 스토리지) |
+
+**SQLite 선택 이유 (MVP):**
+- 별도 서버 불필요 (비용 절감)
+- 설정 간단, 운영 부담 최소
+- MVP 규모 (동시 10명 이하)에서 충분한 성능
+- 필요시 PostgreSQL로 쉽게 마이그레이션 가능
+
+### 2.4 Message Queue (In-Memory)
+
+| 항목 | 설명 |
+|------|------|
+| Implementation | Java BlockingQueue 또는 Spring @Async |
+| Purpose | Submit 비동기 처리 |
+| Persistence | 없음 (서버 재시작 시 유실) |
+
+**Redis 대신 인메모리 큐 선택 이유:**
+- 별도 Redis 서버 불필요 (비용 절감)
+- MVP 규모에서 메시지 유실 위험 허용 가능
+- 단일 서버이므로 분산 큐 불필요
+
+```java
+// 간단한 인메모리 큐 구현 예시
+@Service
+public class SubmitQueueService {
+    private final BlockingQueue<SubmitTask> queue = new LinkedBlockingQueue<>(100);
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    @PostConstruct
+    public void startWorkers() {
+        for (int i = 0; i < 2; i++) {
+            executor.submit(this::processQueue);
+        }
+    }
+
+    public void enqueue(SubmitTask task) {
+        queue.offer(task);
+    }
+
+    private void processQueue() {
+        while (true) {
+            try {
+                SubmitTask task = queue.take();
+                processSubmission(task);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+    }
+}
+```
+
+### 2.5 Execution Engine (Judge0)
 
 | 항목 | 설명 |
 |------|------|
 | Deployment | Self-hosted (Docker) |
 | Languages | Python, Java, C++, JavaScript |
 | Isolation | Container-based (isolate) |
-| API Version | Judge0 CE v1.13.0+ |
+| Workers | **1-2개 (최소 구성)** |
 
-**리소스 제한 (기본값):**
+**리소스 제한 (MVP 최소 설정):**
 - CPU: 1 vCPU
-- Memory: 512MB
-- Time Limit: 2-5초 (문제별 설정)
+- Memory: 256MB
+- Time Limit: 5초
 - Network: 완전 차단
+- 동시 실행: 2개
 
-### 2.4 Database (PostgreSQL)
-
-| 항목 | 설명 |
-|------|------|
-| Version | PostgreSQL 15+ |
-| Connection Pool | HikariCP |
-| Migration | Flyway |
-
-### 2.5 Message Queue (Redis)
-
-| 항목 | 설명 |
-|------|------|
-| Version | Redis 7+ |
-| Purpose | Submit 비동기 큐, 캐시 |
-| Client | Lettuce (Spring Data Redis) |
+---
 
 ## 3. 핵심 플로우
 
@@ -125,46 +186,45 @@
 **특징:**
 - 동기 처리 (즉시 응답)
 - 샘플 테스트케이스만 실행
-- 동시 처리: 50 concurrent
+- **동시 처리: 10 concurrent** (MVP 축소)
 
 ### 3.2 Submit (전체 테스트 제출)
 
 ```
-┌──────┐     ┌──────────┐     ┌───────┐     ┌────────┐     ┌─────────┐
-│Client│────▶│ Backend  │────▶│ Redis │────▶│ Worker │────▶│ Judge0  │
-└──────┘     └──────────┘     └───────┘     └────────┘     └─────────┘
-   │              │               │              │              │
-   │ POST /submit │               │              │              │
-   │─────────────▶│               │              │              │
-   │              │ Enqueue       │              │              │
-   │              │──────────────▶│              │              │
-   │ 202 Accepted │               │              │              │
-   │◀─────────────│               │              │              │
-   │              │               │  Dequeue     │              │
-   │              │               │─────────────▶│              │
-   │              │               │              │  Execute     │
-   │              │               │              │─────────────▶│
-   │              │               │              │  Result      │
-   │              │               │              │◀─────────────│
-   │              │ Update Status │              │              │
-   │              │◀──────────────────────────────│              │
-   │              │               │              │              │
-   │ GET /submissions/{id}        │              │              │
-   │─────────────▶│               │              │              │
-   │ 200 OK       │               │              │              │
-   │◀─────────────│               │              │              │
+┌──────┐     ┌──────────┐     ┌───────────┐     ┌─────────┐
+│Client│────▶│ Backend  │────▶│ In-Memory │────▶│ Judge0  │
+└──────┘     └──────────┘     │   Queue   │     └─────────┘
+   │              │           └───────────┘          │
+   │ POST /submit │                 │                │
+   │─────────────▶│                 │                │
+   │              │ Enqueue         │                │
+   │              │────────────────▶│                │
+   │ 202 Accepted │                 │                │
+   │◀─────────────│                 │                │
+   │              │                 │  Dequeue &    │
+   │              │                 │  Execute      │
+   │              │                 │──────────────▶│
+   │              │                 │  Result       │
+   │              │                 │◀──────────────│
+   │              │ Update DB       │                │
+   │              │◀────────────────│                │
+   │              │                 │                │
+   │ GET /submissions/{id}          │                │
+   │─────────────▶│                 │                │
+   │ 200 OK       │                 │                │
+   │◀─────────────│                 │                │
 ```
 
 **특징:**
-- 비동기 처리 (큐 기반)
+- 비동기 처리 (인메모리 큐 기반)
 - 전체 테스트케이스 실행 (샘플 + 숨김)
 - 상태 머신: `queued` → `running` → `done`
-- 동시 처리: 20 concurrent (워커 확장 가능)
+- **동시 처리: 5 concurrent** (MVP 축소)
 
 ### 3.3 제출 상태 조회 (Polling)
 
 ```
-Client                    Backend                   Database
+Client                    Backend                   SQLite
    │                         │                          │
    │  GET /submissions/{id}  │                          │
    │────────────────────────▶│                          │
@@ -184,119 +244,192 @@ Client                    Backend                   Database
    │◀────────────────────────│                          │
 ```
 
-## 4. 동시성 & 확장성
+---
 
-### 4.1 동시 처리 목표
+## 4. 동시성 & 확장성 (MVP)
+
+### 4.1 동시 처리 목표 (MVP 축소)
 
 | 작업 | 목표 동시성 | 처리 방식 |
 |------|-------------|-----------|
-| Run | 50 concurrent | 동기 (Judge0 직접 호출) |
-| Submit | 20 concurrent | 비동기 (Redis Queue + Worker) |
+| Run | **10 concurrent** | 동기 (Judge0 직접 호출) |
+| Submit | **5 concurrent** | 비동기 (인메모리 큐) |
 
-### 4.2 확장 전략
+> **Note**: MVP에서는 유저가 거의 없으므로 낮은 동시성으로 충분
+
+### 4.2 단일 서버 구성
 
 ```
-                    ┌─────────────┐
-                    │Load Balancer│
-                    └──────┬──────┘
-           ┌───────────────┼───────────────┐
-           ▼               ▼               ▼
-    ┌────────────┐  ┌────────────┐  ┌────────────┐
-    │ API Server │  │ API Server │  │ API Server │
-    │     #1     │  │     #2     │  │     #3     │
-    └────────────┘  └────────────┘  └────────────┘
-           │               │               │
-           └───────────────┼───────────────┘
-                           ▼
-                    ┌─────────────┐
-                    │ Redis Queue │
-                    └──────┬──────┘
-           ┌───────────────┼───────────────┐
-           ▼               ▼               ▼
-    ┌────────────┐  ┌────────────┐  ┌────────────┐
-    │   Worker   │  │   Worker   │  │   Worker   │
-    │     #1     │  │     #2     │  │     #3     │
-    └────────────┘  └────────────┘  └────────────┘
-           │               │               │
-           └───────────────┼───────────────┘
-                           ▼
-                    ┌─────────────┐
-                    │   Judge0    │
-                    │   Cluster   │
-                    └─────────────┘
+┌─────────────────────────────────────────────────┐
+│                  Single VM                       │
+│  ┌───────────────────────────────────────────┐  │
+│  │           Spring Boot Application          │  │
+│  │                                            │  │
+│  │  ┌─────────────┐    ┌─────────────────┐   │  │
+│  │  │   API       │    │   Submit Queue  │   │  │
+│  │  │  Handlers   │    │   (In-Memory)   │   │  │
+│  │  │  (Tomcat)   │    │   + Workers     │   │  │
+│  │  └──────┬──────┘    └────────┬────────┘   │  │
+│  │         │                    │            │  │
+│  │         └────────┬───────────┘            │  │
+│  │                  │                        │  │
+│  │                  ▼                        │  │
+│  │         ┌─────────────┐                   │  │
+│  │         │   SQLite    │                   │  │
+│  │         │   (File)    │                   │  │
+│  │         └─────────────┘                   │  │
+│  └───────────────────────────────────────────┘  │
+│                                                  │
+│  ┌───────────────────────────────────────────┐  │
+│  │              Judge0 (Docker)               │  │
+│  │   - 2 Workers max                         │  │
+│  │   - PostgreSQL (Judge0 전용)               │  │
+│  │   - Redis (Judge0 전용)                    │  │
+│  └───────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────┘
 ```
 
-**수평 확장 포인트:**
-1. API Server: Stateless → LB 뒤에서 무한 확장
-2. Worker: Redis 큐 기반 → 워커 수 증가로 처리량 확장
-3. Judge0: 여러 인스턴스 운영 가능
+### 4.3 향후 확장 (필요시)
+
+```
+Phase 1 (MVP)           Phase 2 (성장)           Phase 3 (확장)
+┌─────────────┐       ┌─────────────┐       ┌─────────────┐
+│  Single VM  │  ──▶  │  Bigger VM  │  ──▶  │  Multiple   │
+│  + SQLite   │       │  + Postgres │       │  Servers    │
+└─────────────┘       └─────────────┘       └─────────────┘
+ 동시 10/5             동시 30/15             동시 50+/20+
+ 월 ~₩0               월 ~₩30,000           월 ~₩100,000+
+```
+
+---
 
 ## 5. 보안 아키텍처
 
-### 5.1 네트워크 보안
+### 5.1 네트워크 보안 (간소화)
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                        Public Zone                          │
-│  ┌─────────────────────────────────────────────────────┐   │
-│  │              Load Balancer (HTTPS only)              │   │
-│  └─────────────────────────────────────────────────────┘   │
+│                       Internet                               │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │                   Cloudflare                         │    │
+│  │               (DNS + DDoS 방어)                      │    │
+│  └─────────────────────────────────────────────────────┘    │
 └─────────────────────────────────────────────────────────────┘
                               │
-                              │ Internal Network
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                       Private Zone                          │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐        │
-│  │ API Server  │  │    Redis    │  │ PostgreSQL  │        │
-│  └─────────────┘  └─────────────┘  └─────────────┘        │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              │ Isolated Network
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                      Execution Zone                         │
-│  ┌─────────────────────────────────────────────────────┐   │
-│  │  Judge0 (No outbound network, resource limited)     │   │
-│  └─────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────┘
+              ┌───────────────┴───────────────┐
+              │                               │
+              ▼                               ▼
+     ┌────────────────┐              ┌────────────────┐
+     │     Vercel     │              │   Single VM    │
+     │   (Frontend)   │              │    (Backend)   │
+     │   HTTPS only   │              │  Nginx + SSL   │
+     └────────────────┘              └────────────────┘
+                                              │
+                                     ┌────────┴────────┐
+                                     │  Judge0 Docker  │
+                                     │  (No outbound)  │
+                                     └─────────────────┘
 ```
 
 ### 5.2 애플리케이션 보안
 
 | 계층 | 보안 조치 |
 |------|-----------|
-| API | Rate limiting (IP/세션 기준) |
-| Input | 코드 크기 제한, 입력값 검증 |
-| Execution | 컨테이너 격리, 리소스 제한, 네트워크 차단 |
+| API | Rate limiting (IP 기준, 간단한 구현) |
+| Input | 코드 크기 제한 (10KB), 입력값 검증 |
+| Execution | Docker 컨테이너 격리, 리소스 제한, 네트워크 차단 |
 | Data | 숨김 테스트케이스 비공개, 상세 로그 미노출 |
 
-## 6. 모니터링 & 로깅
+### 5.3 간단한 Rate Limiting 구현
 
-### 6.1 메트릭 수집
+```java
+@Component
+public class SimpleRateLimiter {
+    private final Map<String, Deque<Long>> requestLog = new ConcurrentHashMap<>();
 
-| 메트릭 | 도구 | 목적 |
-|--------|------|------|
-| API Latency | Micrometer + Prometheus | P95 응답시간 모니터링 |
-| Queue Depth | Redis INFO | Submit 적체 감지 |
-| Judge0 Status | Health Check | 실행 엔진 상태 |
-| Error Rate | Application Logs | 장애 탐지 |
+    public boolean isAllowed(String ip, int maxRequests, int windowSeconds) {
+        long now = System.currentTimeMillis();
+        long windowStart = now - (windowSeconds * 1000L);
 
-### 6.2 핵심 SLI/SLO
+        requestLog.computeIfAbsent(ip, k -> new ConcurrentLinkedDeque<>());
+        Deque<Long> timestamps = requestLog.get(ip);
+
+        // 오래된 기록 제거
+        while (!timestamps.isEmpty() && timestamps.peekFirst() < windowStart) {
+            timestamps.pollFirst();
+        }
+
+        if (timestamps.size() >= maxRequests) {
+            return false;
+        }
+
+        timestamps.addLast(now);
+        return true;
+    }
+}
+```
+
+---
+
+## 6. 모니터링 & 로깅 (MVP)
+
+### 6.1 간단한 로깅
+
+```yaml
+# application.yml
+logging:
+  level:
+    root: INFO
+    com.ctsystem: DEBUG
+  file:
+    name: /var/log/ct-system/app.log
+    max-size: 10MB
+    max-history: 7
+```
+
+### 6.2 핵심 메트릭 (Spring Actuator)
+
+```yaml
+# application.yml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+  endpoint:
+    health:
+      show-details: when_authorized
+```
+
+### 6.3 핵심 SLI/SLO (MVP)
 
 | SLI | SLO | 측정 방법 |
 |-----|-----|-----------|
 | Submit 응답 시간 | P95 < 10초 | 제출 → done 상태까지 |
 | 제출 완료율 | 90%+ | 성공 제출 / 전체 제출 |
-| API 가용성 | 99.5% | Uptime 모니터링 |
+| API 가용성 | 95%+ | UptimeRobot 모니터링 |
+
+> **Note**: MVP에서는 99% 가용성 목표 대신 95%로 완화
+
+---
 
 ## 7. 기술 부채 & 향후 고려사항
 
 ### MVP에서 제외 (로드맵)
 
-| 항목 | 이유 | 향후 계획 |
-|------|------|-----------|
-| WebSocket | Polling으로 충분 | 실시간 피드백 필요시 도입 |
-| gVisor/Firecracker | 교육용 MVP | 채용 플랫폼 확장시 검토 |
-| 분산 캐시 | 단일 Redis로 충분 | 트래픽 증가시 Redis Cluster |
-| 사용자 인증 | 게스트 only MVP | OAuth/JWT 추가 예정 |
+| 항목 | 현재 상태 | 향후 계획 |
+|------|-----------|-----------|
+| WebSocket | Polling 사용 | 실시간 피드백 필요시 도입 |
+| PostgreSQL | SQLite 사용 | 트래픽 증가시 마이그레이션 |
+| Redis | 인메모리 큐 | 분산 환경 필요시 도입 |
+| 사용자 인증 | 게스트 only | OAuth/JWT 추가 예정 |
+| 자동 스케일링 | 단일 서버 | 클라우드 마이그레이션시 |
+| 고가용성 | 단일 장애점 | 트래픽 증가시 구성 |
+
+### SQLite → PostgreSQL 마이그레이션 기준
+
+다음 조건 중 하나라도 해당되면 PostgreSQL로 마이그레이션:
+1. 동시 접속자 20명 이상 빈번
+2. DB 파일 크기 1GB 초과
+3. 복잡한 쿼리 성능 이슈 발생
+4. 다중 서버 구성 필요

--- a/docs/architecture/TECH_STACK_DECISION.md
+++ b/docs/architecture/TECH_STACK_DECISION.md
@@ -2,28 +2,37 @@
 
 기술 스택 선택의 근거와 대안 비교를 문서화합니다.
 
+## 0. 비용 목표
+
+**MVP 월 운영비 목표: 1만원 이하 (~$7-8 USD)**
+
+이 목표를 달성하기 위해 모든 기술 선택에서 비용을 최우선으로 고려합니다.
+
+---
+
 ## 1. Frontend
 
 ### 선택: Next.js 14+ (App Router)
 
 | 평가 기준 | Next.js | Create React App | Vite + React |
 |-----------|---------|------------------|--------------|
-| SSR/SSG 지원 | ✅ 내장 | ❌ | ❌ |
-| 라우팅 | ✅ 파일 기반 | ❌ 별도 설정 | ❌ 별도 설정 |
-| SEO | ✅ 우수 | ⚠️ 제한적 | ⚠️ 제한적 |
-| DX (개발 경험) | ✅ 우수 | ✅ 우수 | ✅ 우수 |
-| 배포 용이성 | ✅ Vercel 최적화 | ✅ | ✅ |
-| 생태계 | ✅ 풍부 | ✅ 풍부 | ✅ 성장 중 |
+| SSR/SSG 지원 | O 내장 | X | X |
+| 라우팅 | O 파일 기반 | X 별도 설정 | X 별도 설정 |
+| SEO | O 우수 | - 제한적 | - 제한적 |
+| DX (개발 경험) | O 우수 | O 우수 | O 우수 |
+| **무료 호스팅** | **O Vercel Free** | - Netlify | - Netlify |
+| 생태계 | O 풍부 | O 풍부 | O 성장 중 |
 
 **선택 이유:**
-1. **SEO 필요성**: 문제 리스트 페이지는 검색 엔진 노출이 필요할 수 있음
-2. **API Routes**: 간단한 BFF(Backend for Frontend) 패턴 적용 가능
-3. **파일 기반 라우팅**: 빠른 개발 속도
-4. **Vercel 배포**: MVP 단계에서 인프라 관리 최소화
+1. **Vercel Free Tier**: 프론트엔드 호스팅 비용 **₩0**
+2. **SEO 필요성**: 문제 리스트 페이지는 검색 엔진 노출이 필요할 수 있음
+3. **API Routes**: 간단한 BFF(Backend for Frontend) 패턴 적용 가능
+4. **파일 기반 라우팅**: 빠른 개발 속도
 
-**리스크:**
-- App Router 학습 곡선 (Pages Router 대비)
-- 서버 컴포넌트 개념 이해 필요
+**Vercel Free Tier 제한:**
+- 100GB 대역폭/월
+- 빌드 시간 6000분/월
+- 상업적 사용 가능
 
 ---
 
@@ -31,20 +40,15 @@
 
 | 평가 기준 | shadcn/ui | MUI | Ant Design | Chakra UI |
 |-----------|-----------|-----|------------|-----------|
-| 번들 크기 | ✅ 최소 (필요한 것만) | ❌ 큼 | ❌ 큼 | ⚠️ 중간 |
-| 커스터마이징 | ✅ 완전한 소유권 | ⚠️ 테마 제한 | ⚠️ 테마 제한 | ✅ 좋음 |
-| Tailwind 호환 | ✅ 네이티브 | ❌ | ❌ | ⚠️ 부분적 |
-| 디자인 품질 | ✅ 모던 | ✅ Material | ✅ Enterprise | ✅ 깔끔 |
-| 접근성 | ✅ Radix 기반 | ✅ | ✅ | ✅ |
+| 번들 크기 | O 최소 | X 큼 | X 큼 | - 중간 |
+| 커스터마이징 | O 완전한 소유권 | - 테마 제한 | - 테마 제한 | O 좋음 |
+| Tailwind 호환 | O 네이티브 | X | X | - 부분적 |
+| **비용 (라이선스)** | **O 무료** | **O 무료** | **O 무료** | **O 무료** |
 
 **선택 이유:**
 1. **코드 소유권**: 복사-붙여넣기 방식으로 완전한 커스터마이징 가능
-2. **번들 최적화**: 사용하는 컴포넌트만 포함
-3. **Tailwind CSS**: 빠른 스타일링, 일관된 디자인 시스템
-4. **Radix UI 기반**: 접근성 보장
-
-**리스크:**
-- 컴포넌트 직접 관리 필요 (업데이트 수동)
+2. **번들 최적화**: 사용하는 컴포넌트만 포함 → Vercel 대역폭 절약
+3. **Tailwind CSS**: 빠른 스타일링
 
 ---
 
@@ -52,20 +56,18 @@
 
 | 평가 기준 | Monaco | CodeMirror 6 | Ace Editor |
 |-----------|--------|--------------|------------|
-| VS Code 호환 | ✅ 동일 엔진 | ❌ | ❌ |
-| 언어 지원 | ✅ 풍부 | ✅ 플러그인 | ✅ |
-| 자동완성 | ✅ IntelliSense | ⚠️ 기본적 | ⚠️ 기본적 |
-| 번들 크기 | ❌ 큼 (~2MB) | ✅ 작음 | ✅ 작음 |
-| 사용자 친숙도 | ✅ VS Code 경험 | ⚠️ | ⚠️ |
+| VS Code 호환 | O 동일 엔진 | X | X |
+| 언어 지원 | O 풍부 | O 플러그인 | O |
+| 번들 크기 | X 큼 (~2MB) | O 작음 | O 작음 |
+| 사용자 친숙도 | O VS Code 경험 | - | - |
 
 **선택 이유:**
 1. **VS Code 경험**: 대부분의 개발자가 익숙한 UX
 2. **언어 지원**: Python, Java, C++, JavaScript 모두 내장 지원
-3. **IntelliSense**: 기본적인 자동완성 제공
 
-**리스크:**
-- 번들 크기 (~2MB) → Dynamic import로 완화
-- 모바일 지원 제한적 (MVP에서는 데스크톱 우선)
+**번들 크기 완화:**
+- Dynamic import로 초기 로딩 최적화
+- 모바일은 MVP에서 지원 안함 (데스크톱 우선)
 
 ---
 
@@ -73,116 +75,225 @@
 
 ### 선택: Spring Boot 3.x (Java 17+)
 
-| 평가 기준 | Spring Boot | Node.js (Express/Nest) | Go (Gin/Echo) | Python (FastAPI) |
-|-----------|-------------|------------------------|---------------|------------------|
-| 타입 안정성 | ✅ 강타입 | ⚠️ TS 필요 | ✅ 강타입 | ⚠️ 힌트 기반 |
-| 생태계 | ✅ 방대함 | ✅ 방대함 | ⚠️ 성장 중 | ✅ 좋음 |
-| ORM | ✅ JPA/Hibernate | ✅ Prisma/TypeORM | ⚠️ GORM | ✅ SQLAlchemy |
-| 동시성 처리 | ✅ Virtual Threads | ✅ Event Loop | ✅ Goroutine | ⚠️ asyncio |
-| 채용 시장 | ✅ 한국 시장 우세 | ✅ | ⚠️ | ✅ |
-| 엔터프라이즈 적합성 | ✅ 검증됨 | ⚠️ 프로젝트마다 다름 | ⚠️ | ⚠️ |
+| 평가 기준 | Spring Boot | Node.js (NestJS) | Go (Gin) | Python (FastAPI) |
+|-----------|-------------|------------------|----------|------------------|
+| 타입 안정성 | O 강타입 | - TS 필요 | O 강타입 | - 힌트 기반 |
+| ORM | O JPA/Hibernate | O Prisma | - GORM | O SQLAlchemy |
+| **메모리 사용** | **X 높음** | **O 낮음** | **O 최저** | **O 낮음** |
+| 채용 시장 | O 한국 우세 | O | - | O |
+| SQLite 지원 | O | O | O | O |
 
 **선택 이유:**
 1. **안정성**: 오랜 기간 검증된 프레임워크
-2. **JPA**: 복잡한 쿼리도 타입 안전하게 처리
-3. **Virtual Threads (Java 21)**: 높은 동시성 처리 가능
-4. **한국 시장**: 백엔드 인력 풀이 풍부
-5. **확장 경험**: 향후 교육 플랫폼 확장 시 엔터프라이즈 기능 활용
+2. **JPA + SQLite**: Hibernate의 SQLite 지원으로 쉬운 DB 연동
+3. **한국 시장**: 백엔드 인력 풀이 풍부
+4. **향후 확장**: 엔터프라이즈 기능 활용 용이
 
-**리스크:**
-- Node.js 대비 초기 설정 복잡
-- 메모리 사용량 상대적으로 높음
+**메모리 최적화:**
+```yaml
+# application.yml - 메모리 제한 환경에서
+server:
+  tomcat:
+    threads:
+      max: 20
+      min-spare: 5
+```
 
 **대안 검토 - Node.js (NestJS):**
-- 풀스택 JavaScript로 팀 구성 단순화 가능
-- 하지만 타입 안정성과 엔터프라이즈 확장성에서 Spring이 우위
+- 메모리 사용량이 적어 저사양 VPS에 유리
+- MVP 규모에서는 Spring Boot도 충분히 가볍게 운영 가능
 
 ---
 
-### 선택: PostgreSQL 15+
+### 선택: SQLite (MVP) → PostgreSQL (확장시)
 
-| 평가 기준 | PostgreSQL | MySQL | MongoDB |
-|-----------|------------|-------|---------|
-| ACID 준수 | ✅ 완전 | ✅ 완전 | ⚠️ 설정 필요 |
-| JSON 지원 | ✅ JSONB | ⚠️ 기본 JSON | ✅ 네이티브 |
-| 성능 | ✅ 복잡 쿼리 강점 | ✅ 읽기 강점 | ✅ 쓰기 강점 |
-| 확장성 | ✅ | ✅ | ✅ |
-| 생태계 | ✅ | ✅ | ✅ |
+| 평가 기준 | SQLite | PostgreSQL | MySQL |
+|-----------|--------|------------|-------|
+| **서버 비용** | **O ₩0** | **X 추가 비용** | **X 추가 비용** |
+| 설정 복잡도 | O 없음 | X 서버 필요 | X 서버 필요 |
+| 동시성 | X 제한적 | O 우수 | O 우수 |
+| ACID | O | O | O |
+| JSON 지원 | O 기본 | O JSONB | - |
+| 백업 | O 파일 복사 | - 덤프 필요 | - 덤프 필요 |
 
-**선택 이유:**
-1. **JSONB**: 테스트케이스 등 반정형 데이터 효율적 저장
-2. **복잡 쿼리 성능**: 제출 통계, 리포팅에 유리
-3. **오픈소스**: 라이선스 비용 없음
-4. **AWS RDS 지원**: 관리형 서비스 쉽게 사용
+**SQLite 선택 이유 (MVP):**
+1. **비용 ₩0**: 별도 DB 서버 불필요
+2. **단순성**: 설치/설정 없이 즉시 사용
+3. **백업 용이**: 파일 복사만으로 백업 완료
+4. **JPA 호환**: Spring Data JPA로 동일 코드 사용
+
+**SQLite 제한 인지:**
+- 동시 쓰기 제한 (WAL 모드로 완화)
+- 대규모 트래픽 부적합
+- **MVP 규모 (동시 10명)에서는 문제없음**
+
+**마이그레이션 전략:**
+```java
+// application.yml - 환경별 DB 설정
+spring:
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:local}
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:sqlite:./data/ct_system.db
+    driver-class-name: org.sqlite.JDBC
+
+---
+spring:
+  config:
+    activate:
+      on-profile: production-scaled
+  datasource:
+    url: jdbc:postgresql://localhost:5432/ct_system
+    driver-class-name: org.postgresql.Driver
+```
 
 ---
 
-### 선택: Redis 7+
+### 선택: In-Memory Queue (MVP) → Redis (확장시)
 
-| 평가 기준 | Redis | RabbitMQ | Apache Kafka |
-|-----------|-------|----------|--------------|
-| 설정 복잡도 | ✅ 단순 | ⚠️ 중간 | ❌ 복잡 |
-| 메시지 큐 | ✅ List/Stream | ✅ 전문 MQ | ✅ 대용량 |
-| 캐시 기능 | ✅ 본업 | ❌ | ❌ |
-| 지연시간 | ✅ 초저지연 | ✅ 낮음 | ⚠️ 배치 최적화 |
-| MVP 적합성 | ✅ | ⚠️ 오버스펙 | ❌ 오버스펙 |
+| 평가 기준 | In-Memory (BlockingQueue) | Redis | RabbitMQ |
+|-----------|---------------------------|-------|----------|
+| **서버 비용** | **O ₩0** | **X ~$10/월** | **X ~$15/월** |
+| 설정 복잡도 | O 없음 | - 별도 서버 | X 복잡 |
+| 영속성 | X 없음 | O | O |
+| 분산 환경 | X | O | O |
+| MVP 적합성 | O | - 오버스펙 | X 오버스펙 |
 
-**선택 이유:**
-1. **다목적**: 캐시 + 메시지 큐 + 세션 저장소를 하나로
-2. **단순성**: 운영 부담 최소화
-3. **Submit 큐**: Redis List로 간단한 작업 큐 구현
-4. **Spring 통합**: Spring Data Redis로 쉬운 연동
+**In-Memory Queue 선택 이유:**
+1. **비용 ₩0**: Redis 서버 불필요
+2. **단순성**: 추가 인프라 없이 구현
+3. **MVP 충분**: 단일 서버에서 분산 큐 불필요
+4. **유실 허용**: 서버 재시작시 큐 유실 허용 (MVP)
 
-**한계:**
-- 메시지 영속성 보장이 RabbitMQ 대비 약함
-- MVP 규모에서는 문제없음, 확장 시 재검토
+**구현 방식:**
+```java
+// Spring @Async를 사용한 간단한 비동기 처리
+@Service
+public class SubmitService {
+
+    @Async
+    public CompletableFuture<SubmissionResult> processSubmission(SubmitRequest request) {
+        // Judge0 호출 및 결과 처리
+        return CompletableFuture.completedFuture(result);
+    }
+}
+```
+
+**Redis 도입 기준:**
+1. 다중 서버 구성 필요시
+2. 큐 메시지 영속성 필요시
+3. 캐시 레이어 필요시
 
 ---
 
 ## 3. Execution Engine
 
-### 선택: Judge0 (Self-hosted)
+### 선택: Judge0 (Self-hosted, 최소 구성)
 
 | 평가 기준 | Judge0 | 자체 구현 | Sphere Engine | HackerRank API |
 |-----------|--------|-----------|---------------|----------------|
-| 구현 비용 | ✅ 즉시 사용 | ❌ 높음 | ✅ | ✅ |
-| 커스터마이징 | ✅ 오픈소스 | ✅ 완전 | ❌ 제한적 | ❌ 제한적 |
-| 보안 격리 | ✅ isolate 기반 | ⚠️ 직접 구현 | ✅ | ✅ |
-| 비용 | ✅ 무료 | ✅ 인프라만 | ❌ 유료 | ❌ 유료 |
-| 언어 지원 | ✅ 60+ 언어 | ⚠️ 직접 추가 | ✅ | ✅ |
+| **구현 비용** | O 즉시 사용 | X 높음 | O | O |
+| **운영 비용** | **O Self-hosted** | O 인프라만 | **X 유료** | **X 유료** |
+| 커스터마이징 | O 오픈소스 | O 완전 | X 제한적 | X 제한적 |
+| 보안 격리 | O isolate | - 직접 구현 | O | O |
 
 **선택 이유:**
-1. **빠른 MVP**: 검증된 실행 엔진 즉시 사용
-2. **오픈소스**: 필요시 커스터마이징 가능
-3. **isolate 기반**: 리눅스 컨테이너 수준 격리 제공
-4. **4개 언어 지원**: Python, Java, C++, JavaScript 모두 지원
+1. **비용 ₩0**: Self-hosted로 추가 비용 없음
+2. **빠른 MVP**: 검증된 실행 엔진 즉시 사용
+3. **오픈소스**: 필요시 커스터마이징 가능
 
-**리스크:**
-- Self-hosted 운영 부담
-- 고도화된 보안 필요시 추가 작업 필요 (gVisor 등)
-
----
-
-## 4. 결정 요약
-
-| 계층 | 선택 | 핵심 이유 |
-|------|------|-----------|
-| Frontend Framework | Next.js 14+ | SSR, 파일 라우팅, Vercel 배포 |
-| UI Library | shadcn/ui | 번들 최적화, 커스터마이징 |
-| Code Editor | Monaco | VS Code UX, 언어 지원 |
-| Backend Framework | Spring Boot 3.x | 안정성, JPA, 확장성 |
-| Database | PostgreSQL 15+ | JSONB, 복잡 쿼리, 오픈소스 |
-| Message Queue/Cache | Redis 7+ | 다목적, 단순성 |
-| Execution Engine | Judge0 | 빠른 MVP, 오픈소스 |
+**최소 리소스 구성:**
+```yaml
+# Judge0 환경 변수 (최소 설정)
+environment:
+  - MAX_NUMBER_OF_CONCURRENT_JOBS=2  # 워커 2개로 제한
+  - MAX_QUEUE_SIZE=10                # 큐 사이즈 제한
+  - MEMORY_LIMIT=256000              # 256MB로 제한
+  - CPU_TIME_LIMIT=5                 # 5초 제한
+```
 
 ---
 
-## 5. 향후 재검토 시점
+## 4. Infrastructure
+
+### 선택: Oracle Cloud Free Tier (권장) / 저가 VPS (대안)
+
+| 평가 기준 | Oracle Cloud Free | Vultr ($5) | AWS (기존) |
+|-----------|-------------------|------------|------------|
+| **월 비용** | **O ₩0** | **O ~₩7,000** | **X ~₩180,000** |
+| 스펙 | 4 OCPU, 24GB RAM | 1 vCPU, 1GB RAM | 다양 |
+| 관리 편의성 | - | - | O 관리형 |
+| 확장성 | X 제한적 | - 수동 | O 자동 |
+
+**Oracle Cloud Free 선택 이유:**
+1. **완전 무료**: ARM VM 4 OCPU, 24GB RAM 영구 무료
+2. **충분한 스펙**: MVP에 과할 정도로 여유로운 리소스
+3. **글로벌**: 한국 리전 지원
+
+**저가 VPS 대안 (Oracle 사용 불가시):**
+- Hetzner CX21: €4.35/월 (2 vCPU, 4GB RAM)
+- Contabo VPS S: €5.99/월 (4 vCPU, 8GB RAM)
+
+---
+
+## 5. 결정 요약
+
+### 비용 최적화 기술 스택
+
+| 계층 | 선택 | 비용 | 핵심 이유 |
+|------|------|------|-----------|
+| Frontend Hosting | Vercel Free | **₩0** | 무료 호스팅, CDN |
+| Frontend Framework | Next.js 14+ | - | SSR, Vercel 최적화 |
+| UI Library | shadcn/ui | - | 번들 최소화 |
+| Code Editor | Monaco | - | VS Code UX |
+| Backend Framework | Spring Boot 3.x | - | 안정성, JPA |
+| **Database** | **SQLite** | **₩0** | 서버 불필요 |
+| **Message Queue** | **In-Memory** | **₩0** | Redis 불필요 |
+| Execution Engine | Judge0 Self-hosted | **₩0** | 오픈소스 |
+| **Server** | **Oracle Free/저가 VPS** | **₩0~7,000** | 무료/저가 |
+
+### 월 비용 총계
+
+| 구성 | 비용 |
+|------|------|
+| **Oracle Cloud Free** | **₩0** |
+| **저가 VPS** | **~₩7,000** |
+| 기존 AWS 구성 | ~₩180,000 |
+
+---
+
+## 6. 향후 재검토 시점
 
 | 기술 | 재검토 트리거 | 대안 |
 |------|---------------|------|
-| Next.js | 복잡한 상태 관리 필요시 | React + Vite + React Router |
-| Spring Boot | 마이크로서비스 분리시 | Go/Node.js for specific services |
-| PostgreSQL | 초대용량 쓰기 부하시 | Sharding 또는 NoSQL 부분 도입 |
-| Redis | 메시지 보장 필요시 | RabbitMQ 또는 Kafka |
-| Judge0 | 채용 플랫폼 확장시 | gVisor/Firecracker 기반 자체 구현 |
+| SQLite | 동시 20명+ 빈번, DB 1GB+ | PostgreSQL |
+| In-Memory Queue | 다중 서버 필요, 메시지 영속성 필요 | Redis |
+| Oracle Free | 무료 티어 제한 도달 | Hetzner/Contabo |
+| Spring Boot | 메모리 부족 이슈 | Node.js (NestJS) |
+| Judge0 | 채용 플랫폼 확장 | gVisor 기반 자체 구현 |
+
+---
+
+## 7. 비용 vs 기능 트레이드오프
+
+### 포기한 것들 (비용 절감을 위해)
+
+| 기능 | 대안 | 영향 |
+|------|------|------|
+| 고가용성 | 단일 서버 | 다운타임 발생 가능 |
+| 자동 스케일링 | 수동 확장 | 트래픽 급증시 느림 |
+| 메시지 영속성 | 인메모리 큐 | 재시작시 큐 유실 |
+| 관리형 DB | SQLite | 직접 백업 필요 |
+
+### MVP에서 허용 가능한 이유
+
+1. **유저 거의 없음**: 초기 MVP는 소수 사용자
+2. **다운타임 허용**: 교육용 서비스로 24/7 가용성 불필요
+3. **데이터 손실 최소**: 큐 유실되어도 재시도 가능
+4. **비용 > 안정성**: MVP 검증이 우선


### PR DESCRIPTION
월 1만원 이하 운영을 목표로 인프라 설계를 대폭 변경:

- AWS 기반 구성(~$140/월) → Oracle Cloud Free/저가 VPS(₩0~7,000/월)
- PostgreSQL → SQLite (서버 불필요)
- Redis → 인메모리 큐 (Redis 서버 불필요)
- 다중 서버 → 단일 VM 구성
- 동시성 목표 축소: Run 50→10, Submit 20→5