### PR TITLE
fix(ci): allow claude[bot] in code review action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "claude[bot]"
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary
- Claude Code Review Action에서 Bot 트리거 시 실패하는 문제 해결
- `allowed_bots: "claude[bot]"` 파라미터 추가로 claude 봇이 생성한 PR에서도 워크플로우 정상 실행

## Changes
- `.github/workflows/claude-code-review.yml`: `allowed_bots` 설정 추가

## Test plan
- [ ] Claude 봇이 생성한 PR에서 Code Review Action 정상 실행 확인

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)