### PR TITLE
feat(ci): configure Claude Code actions to use Opus 4.5 model

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,4 +42,6 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+          claude_args: |
+            --model claude-opus-4-5-20251101
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,6 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: |
+            --model claude-opus-4-5-20251101
 


### PR DESCRIPTION
## Summary
- GitHub Actions의 Claude Code Action에 Opus 4.5 모델(`claude-opus-4-5-20251101`) 설정 추가
- `claude.yml`과 `claude-code-review.yml` 모두에 `claude_args`로 모델 지정

## Changes
- `.github/workflows/claude.yml` - `claude_args`에 모델 설정 추가
- `.github/workflows/claude-code-review.yml` - `claude_args`에 모델 설정 추가

## Test plan
- [ ] PR에서 @claude 멘션하여 Opus 4.5 모델 적용 확인
- [ ] Code review action이 정상 동작하는지 확인

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)